### PR TITLE
Add Stripe payment integration for conference tickets

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,21 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  images: {
+    unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'picsum.photos',
+      },
+    ],
+    minimumCacheTTL: 2592000,
+  },
+  /* config options here */
+};
+
+export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,18 +18,18 @@
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4",
-        "@types/node": "^20",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
-        "eslint": "^9",
+        "@tailwindcss/postcss": "^4.1.18",
+        "@types/node": "^20.11.1",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "eslint": "^9.39.2",
         "eslint-config-next": "16.1.1",
         "prettier": "^3.7.4",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "serve": "^14.2.5",
-        "tailwindcss": "^4",
+        "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-ryJnSmj4UhrGLZZPJ6PKVb4wNPAIkW6iyLy+0TRwazd3L1u0wzMe8RfqevAh2HbcSkoeLiSYnOVDOys4JSGYyg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.0.tgz",
-      "integrity": "sha512-Z82FDl1ByxqPEPrAYYeTQVlx2FSHPe1qwX465c+96IRS3fTdSYRoJcRxg3g2fEG5I69z1dSEWQlNRRr0/677mg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7537,9 +7537,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.4.tgz",
-      "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,57 +1,176 @@
 import React from 'react';
+import { TICKET_CONTENT, STRIPE_PAYMENT_LINKS } from '@/lib/constants';
 
 export default function About() {
   return (
-    <div className="bg-white pt-24 pb-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-3xl text-center">
-          <h1 className="font-display text-ousac-blue mb-6 text-4xl font-bold tracking-tight sm:text-6xl">
-            About OUSAC
-          </h1>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            Established in 2024, the Ontario Universities Sports Analytics
-            Coalition (OUSAC) is a consortium of sports analytics clubs from
-            post-secondary institutions across Ontario.
-          </p>
-        </div>
+    <>
+      <div className="bg-white pt-24 pb-24">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <h1 className="font-display text-ousac-blue mb-6 text-4xl font-bold tracking-tight sm:text-6xl">
+              About OUSAC
+            </h1>
+            <p className="mt-6 text-lg leading-8 text-gray-600">
+              Established in 2024, the Ontario Universities Sports Analytics
+              Coalition (OUSAC) is a consortium of sports analytics clubs from
+              post-secondary institutions across Ontario.
+            </p>
+          </div>
 
-        <div className="mx-auto mt-16 max-w-5xl">
-          <div className="grid grid-cols-1 gap-12 lg:grid-cols-2">
-            <div>
-              <h2 className="font-display text-ousac-black mb-6 text-3xl font-bold">
-                Our Objectives
-              </h2>
-              <ul className="space-y-4">
-                {[
-                  'Facilitate collaboration on projects and teams for hackathons and competitions',
-                  'Share resources for tutorials and workshops to enhance our breadth of data science applications to sport',
-                  'Attend seminars from respected members of the sports analytics community',
-                  'Present research at and attend conferences',
-                ].map((item, idx) => (
-                  <li key={idx} className="flex gap-3">
-                    <span className="bg-ousac-gold flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold text-white">
-                      {idx + 1}
+          <div className="mx-auto mt-16 max-w-5xl">
+            <div className="grid grid-cols-1 gap-12 lg:grid-cols-2">
+              <div>
+                <h2 className="font-display text-ousac-black mb-6 text-3xl font-bold">
+                  Our Objectives
+                </h2>
+                <ul className="space-y-4">
+                  {[
+                    'Facilitate collaboration on projects and teams for hackathons and competitions',
+                    'Share resources for tutorials and workshops to enhance our breadth of data science applications to sport',
+                    'Attend seminars from respected members of the sports analytics community',
+                    'Present research at and attend conferences',
+                  ].map((item, idx) => (
+                    <li key={idx} className="flex gap-3">
+                      <span className="bg-ousac-gold flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold text-white">
+                        {idx + 1}
+                      </span>
+                      <span className="text-gray-700">{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="rounded-2xl border border-gray-100 bg-gray-50 p-8">
+                <h2 className="font-display text-ousac-black mb-6 text-3xl font-bold">
+                  Our Vision
+                </h2>
+                <p className="text-lg leading-relaxed text-gray-600">
+                  Organizing this conference is one of the ways that we can
+                  fulfill these objectives, under our vision to jointly grow the
+                  quantitative analysis and applications of analytics to sports
+                  in the province.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Ticket Purchase Section */}
+      <div
+        id="tickets"
+        className="bg-gradient-to-b from-white to-blue-50 pt-24 pb-24"
+      >
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          {/* Section Header */}
+          <div className="mx-auto mb-16 max-w-3xl text-center">
+            <span className="text-ousac-purple mb-2 block text-xs font-bold uppercase tracking-widest">
+              Registration
+            </span>
+            <h2 className="font-display text-ousac-black mb-4 text-4xl font-bold sm:text-5xl">
+              {TICKET_CONTENT.section.title}
+            </h2>
+            <p className="text-xl text-gray-600">
+              {TICKET_CONTENT.section.subtitle}
+            </p>
+            <p className="mt-4 text-gray-500">
+              {TICKET_CONTENT.section.description}
+            </p>
+          </div>
+
+          {/* Pricing Information Card */}
+          <div className="mx-auto mb-12 max-w-3xl rounded-2xl border-2 border-gray-200 bg-white p-8 shadow-lg">
+            <div className="mb-8 text-center">
+              <h3 className="font-display mb-6 text-3xl font-bold text-gray-900">
+                Ticket Pricing
+              </h3>
+              <div className="grid gap-6 md:grid-cols-2">
+                {/* Regular Price */}
+                <div className="rounded-xl bg-gray-50 p-6">
+                  <p className="mb-2 text-sm font-semibold uppercase tracking-wider text-gray-500">
+                    Regular Ticket
+                  </p>
+                  <p className="text-4xl font-bold text-ousac-blue">
+                    $10 <span className="text-lg text-gray-500">CAD</span>
+                  </p>
+                </div>
+
+                {/* Student Price */}
+                <div className="relative overflow-hidden rounded-xl bg-gradient-to-br from-ousac-gold/10 to-ousac-gold/5 p-6">
+                  <div className="absolute top-2 right-2 rounded-full bg-ousac-gold px-3 py-1">
+                    <span className="text-xs font-bold uppercase text-white">
+                      Student
                     </span>
-                    <span className="text-gray-700">{item}</span>
+                  </div>
+                  <p className="mb-2 text-sm font-semibold uppercase tracking-wider text-gray-500">
+                    Student Ticket
+                  </p>
+                  <p className="text-4xl font-bold text-ousac-blue">
+                    $5 <span className="text-lg text-gray-500">CAD</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Features List */}
+            <div className="mb-8">
+              <p className="mb-4 text-center text-sm font-semibold uppercase tracking-wider text-gray-500">
+                All tickets include
+              </p>
+              <ul className="grid gap-3 md:grid-cols-2">
+                {TICKET_CONTENT.regularTicket.features.map((feature, idx) => (
+                  <li key={idx} className="flex items-start gap-3">
+                    <div className="mt-0.5 flex-shrink-0">
+                      <div className="flex h-5 w-5 items-center justify-center rounded-full bg-green-100">
+                        <svg
+                          className="h-3 w-3 text-green-600"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                    <span className="text-sm text-gray-600">{feature}</span>
                   </li>
                 ))}
               </ul>
             </div>
 
-            <div className="rounded-2xl border border-gray-100 bg-gray-50 p-8">
-              <h2 className="font-display text-ousac-black mb-6 text-3xl font-bold">
-                Our Vision
-              </h2>
-              <p className="text-lg leading-relaxed text-gray-600">
-                Organizing this conference is one of the ways that we can
-                fulfill these objectives, under our vision to jointly grow the
-                quantitative analysis and applications of analytics to sports in
-                the province.
+            {/* CTA Button */}
+            <div className="text-center">
+              <a
+                href={STRIPE_PAYMENT_LINKS.regularTicket}
+                className="inline-block w-full rounded-lg bg-ousac-blue px-12 py-4 text-lg font-bold uppercase tracking-wider text-white transition-all hover:bg-ousac-blue/90 hover:shadow-lg md:w-auto"
+              >
+                Get Tickets
+              </a>
+              <p className="mt-4 text-xs text-gray-500">
+                Choose your ticket type at checkout
               </p>
             </div>
           </div>
+
+          {/* Additional Information */}
+          <div className="mx-auto mt-12 max-w-3xl rounded-xl border border-blue-200 bg-white p-6 text-center">
+            <p className="text-sm text-gray-600">
+              Questions about registration?{' '}
+              <a
+                href="mailto:contact@ousac.ca"
+                className="text-ousac-blue font-semibold hover:underline"
+              >
+                Contact us
+              </a>
+            </p>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/app/payment/success/page.tsx
+++ b/src/app/payment/success/page.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import Link from 'next/link';
+import { CheckCircle, Calendar, MapPin, Mail } from 'lucide-react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Payment Successful | OUSAC 2026',
+  description: 'Your OUSAC 2026 Conference registration is confirmed.',
+  robots: 'noindex, nofollow',
+};
+
+export default function PaymentSuccess() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white pt-24 pb-24">
+      <div className="mx-auto max-w-3xl px-6 lg:px-8">
+        <div className="text-center">
+          {/* Success Icon */}
+          <div className="mx-auto mb-8 flex h-24 w-24 items-center justify-center rounded-full bg-green-100">
+            <CheckCircle className="h-16 w-16 text-green-600" />
+          </div>
+
+          {/* Success Message */}
+          <h1 className="font-display text-ousac-blue mb-4 text-4xl font-bold sm:text-5xl">
+            Payment Successful!
+          </h1>
+          <p className="mb-12 text-xl text-gray-600">
+            Thank you for registering for OUSAC 2026. We're excited to see you
+            there!
+          </p>
+
+          {/* Confirmation Details Card */}
+          <div className="mb-12 rounded-2xl border border-gray-200 bg-white p-8 text-left shadow-lg">
+            <h2 className="font-display mb-6 text-2xl font-bold text-gray-900">
+              What's Next?
+            </h2>
+
+            <div className="space-y-4">
+              <div className="flex items-start gap-4">
+                <div className="rounded-lg bg-blue-100 p-2 text-ousac-blue">
+                  <Mail className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="font-semibold text-gray-900">
+                    Check Your Email
+                  </p>
+                  <p className="text-sm text-gray-600">
+                    You'll receive a confirmation email from Stripe with your
+                    receipt and ticket details.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-4">
+                <div className="rounded-lg bg-blue-100 p-2 text-ousac-blue">
+                  <Calendar className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="font-semibold text-gray-900">Save the Date</p>
+                  <p className="text-sm text-gray-600">
+                    March 14, 2026 - Mark your calendar for an incredible day
+                    of sports analytics.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-4">
+                <div className="rounded-lg bg-blue-100 p-2 text-ousac-blue">
+                  <MapPin className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="font-semibold text-gray-900">
+                    Location Details
+                  </p>
+                  <p className="text-sm text-gray-600">
+                    Bahen Centre, University of Toronto - 40 St. George St,
+                    Toronto, ON
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+            <Link
+              href="/conference/schedule"
+              className="inline-flex items-center justify-center rounded-lg bg-ousac-blue px-8 py-3 text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-ousac-blue/90"
+            >
+              View Schedule
+            </Link>
+            <Link
+              href="/conference/speakers"
+              className="inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white px-8 py-3 text-sm font-bold uppercase tracking-wider text-ousac-blue transition-colors hover:border-ousac-blue"
+            >
+              Meet the Speakers
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,6 +33,7 @@ const Navbar: React.FC = () => {
   const MAIN_NAV_ITEMS = [
     { label: 'About', href: '/about' },
     { label: 'Members', href: '/members' },
+    { label: 'Tickets', href: '/about#tickets' },
   ];
 
   return (

--- a/src/components/TicketCard.tsx
+++ b/src/components/TicketCard.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Check, GraduationCap } from 'lucide-react';
+
+interface TicketCardProps {
+  name: string;
+  price: string;
+  features: string[];
+  paymentLink: string;
+  badge?: string;
+  honorSystemNote?: string;
+  isStudent?: boolean;
+}
+
+export function TicketCard({
+  name,
+  price,
+  features,
+  paymentLink,
+  badge,
+  honorSystemNote,
+  isStudent = false,
+}: TicketCardProps) {
+  const [agreedToHonorSystem, setAgreedToHonorSystem] = useState(false);
+
+  const handlePurchase = () => {
+    if (isStudent && !agreedToHonorSystem) {
+      return; // Prevent purchase if checkbox not checked
+    }
+    window.location.href = paymentLink;
+  };
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-2xl border-2 bg-white p-8 shadow-lg transition-all duration-300 hover:shadow-xl ${
+        isStudent
+          ? 'border-ousac-gold'
+          : 'border-gray-200 hover:border-ousac-blue'
+      }`}
+    >
+      {/* Badge */}
+      {badge && (
+        <div className="absolute top-0 right-0 rounded-bl-2xl bg-ousac-gold px-4 py-2">
+          <span className="flex items-center gap-1 text-xs font-bold uppercase tracking-wider text-white">
+            <GraduationCap className="h-4 w-4" />
+            {badge}
+          </span>
+        </div>
+      )}
+
+      {/* Ticket Name */}
+      <h3 className="font-display mb-2 text-2xl font-bold text-gray-900">
+        {name}
+      </h3>
+
+      {/* Price */}
+      <div className="mb-6">
+        <span className="text-5xl font-bold text-ousac-blue">{price}</span>
+        <span className="ml-2 text-gray-500">CAD</span>
+      </div>
+
+      {/* Features List */}
+      <ul className="mb-8 space-y-3">
+        {features.map((feature, idx) => (
+          <li key={idx} className="flex items-start gap-3">
+            <div className="mt-0.5 flex-shrink-0">
+              <div className="flex h-5 w-5 items-center justify-center rounded-full bg-green-100">
+                <Check className="h-3 w-3 text-green-600" />
+              </div>
+            </div>
+            <span className="text-sm text-gray-600">{feature}</span>
+          </li>
+        ))}
+      </ul>
+
+      {/* Honor System Checkbox (Student Only) */}
+      {isStudent && honorSystemNote && (
+        <div className="mb-6 rounded-lg bg-blue-50 p-4">
+          <label className="flex cursor-pointer items-start gap-3">
+            <input
+              type="checkbox"
+              checked={agreedToHonorSystem}
+              onChange={(e) => setAgreedToHonorSystem(e.target.checked)}
+              className="mt-1 h-4 w-4 cursor-pointer rounded border-gray-300 text-ousac-blue focus:ring-2 focus:ring-ousac-blue"
+            />
+            <span className="text-xs text-gray-600">
+              I confirm I am a student. {honorSystemNote}
+            </span>
+          </label>
+        </div>
+      )}
+
+      {/* Purchase Button */}
+      <button
+        onClick={handlePurchase}
+        disabled={isStudent && !agreedToHonorSystem}
+        className={`w-full rounded-lg py-4 text-sm font-bold uppercase tracking-wider transition-all ${
+          isStudent && !agreedToHonorSystem
+            ? 'cursor-not-allowed bg-gray-200 text-gray-400'
+            : 'bg-ousac-blue text-white hover:bg-ousac-blue/90 hover:shadow-md'
+        }`}
+      >
+        {isStudent && !agreedToHonorSystem
+          ? 'Please confirm student status'
+          : 'Purchase Ticket'}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -14,6 +14,48 @@ export const GOOGLE_FORM_REGISTRATION =
   'https://docs.google.com/forms/d/e/1FAIpQLSfHvBEd57RvGRmxztjD1M2PZwhWuNZsap0N4w2VJgPBGA3Sgg/viewform';
 export const GOOGLE_FORM_ABSTRACT = 'https://forms.gle/o7eMqDv9D66DeJTFA';
 
+// Stripe Payment Links (created in Stripe Dashboard)
+export const STRIPE_PAYMENT_LINKS = {
+  regularTicket: 'https://buy.stripe.com/test_fZueVe4Nffp5cwe8zR9Ve00',
+  studentTicket: 'https://buy.stripe.com/test_fZueVe4Nffp5cwe8zR9Ve00', // Same link - customers choose ticket type at checkout
+};
+
+export const TICKET_CONTENT = {
+  section: {
+    title: 'Get Your Ticket',
+    subtitle: 'Join us for an unforgettable day of sports analytics',
+    description:
+      'Secure your spot at OUSAC 2026. All tickets include full access to keynote presentations, panel discussions, student competitions, networking opportunities, and catered lunch.',
+  },
+  regularTicket: {
+    name: 'Regular Ticket',
+    price: '$10',
+    features: [
+      'Full conference access',
+      'Keynote presentations from industry leaders',
+      'Panel discussions and Q&A sessions',
+      'Student research presentations',
+      'Networking opportunities',
+      'Catered lunch included',
+    ],
+  },
+  studentTicket: {
+    name: 'Student Ticket',
+    price: '$5',
+    badge: 'Student Discount',
+    features: [
+      'Full conference access',
+      'Keynote presentations from industry leaders',
+      'Panel discussions and Q&A sessions',
+      'Student research presentations',
+      'Networking opportunities',
+      'Catered lunch included',
+    ],
+    honorSystemNote:
+      'This ticket operates on an honor system. No student verification required.',
+  },
+};
+
 export const SITE_CONTENT = {
   navbar: {
     title: 'OUSAC 2026',


### PR DESCRIPTION
- Add ticket purchase section to /about page with pricing display
- Create payment success page at /payment/success
- Add Stripe payment links configuration in constants
- Add "Tickets" link to navbar
- Create TicketCard component (currently unused)
- Add next.config.mjs for compatibility

Ticket pricing:
- Regular ticket: $10 CAD
- Student ticket: $5 CAD

Users are redirected to Stripe checkout to select and purchase tickets.