### PR TITLE
Update site for post-OUSAC 2026 messaging

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/call-for-papers/page.tsx
+++ b/src/app/call-for-papers/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation';
+
+export default function CallForPapersPage() {
+  notFound();
+}

--- a/src/app/conference/data-challenge/page.tsx
+++ b/src/app/conference/data-challenge/page.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
+import { SITE_CONTENT } from '@/lib/constants';
 
 export const metadata = {
   title: 'Data Challenge Finalists | OUSAC',
   description:
-    'Come see the MLSE UofTSPAN Data Challenge finalists present their work at OUSAC 2026.',
+    'Highlights from the MLSE x UofTSPAN Data Challenge at OUSAC 2026.',
 };
 
 export default function DataChallengePage() {
@@ -48,23 +48,22 @@ export default function DataChallengePage() {
         {/* Simple Call to Action Container */}
         <div className="mb-10 rounded-2xl border border-gray-100 bg-gray-50 p-6 sm:mb-12 sm:p-12">
           <h3 className="mb-3 text-xl font-bold text-gray-900 sm:mb-4 sm:text-2xl">
-            Join the Audience
+            OUSAC 2026 is over!
           </h3>
           <p className="mx-auto mb-6 max-w-lg text-sm leading-relaxed text-gray-600 sm:mb-8 sm:text-base">
-            We invite everyone to attend the OUSAC 2026 conference on March 14,
-            2026, to watch the top 3 finalists present their predictive models
-            live to MLSE and academic experts.
+            Thanks to everyone who joined us to watch the finalists present
+            live. Follow us on Instagram @ousacsportsanalytics to stay tuned for
+            OUSAC 2027.
           </p>
 
-          <Link
-            href="/register"
+          <a
+            href={SITE_CONTENT.socials.instagram}
             className="inline-flex w-full items-center justify-center rounded-full bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:w-auto sm:px-8 sm:py-3.5 sm:text-base"
           >
-            Get Conference Tickets
-          </Link>
+            Follow @ousacsportsanalytics
+          </a>
           <p className="mt-4 px-2 text-xs text-gray-500 sm:px-0 sm:text-sm">
-            Tickets grant access to the entire conference, including all
-            presentations and keynotes.
+            We&apos;ll post OUSAC 2027 updates there first.
           </p>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ import { AnimatedShinyButton } from '@/components/ui/animated-shiny-button';
  * Features:
  * - Animated Hero Section with gradient backgrounds.
  * - Event details summary (Date, Location).
- * - "Registration Open" status indicator.
+ * - Post-event conference update and Instagram CTA.
  * - Auto-rotating Keynote Speaker carousel.
  */
 export default function Home() {
@@ -29,10 +29,6 @@ export default function Home() {
   // State to track the currently displayed speaker index
   const [currentSpeakerIndex, setCurrentSpeakerIndex] = useState(0);
 
-  // State to conditionally show the registration badge based on the date
-  const [showRegistrationBadge, setShowRegistrationBadge] = useState(true);
-  const [showRegistrationCTA, setShowRegistrationCTA] = useState(true);
-
   // EFFECT: Set up an interval to auto-rotate the speaker carousel every 6 seconds
   useEffect(() => {
     if (keynoteSpeakers.length <= 1) return;
@@ -41,24 +37,6 @@ export default function Home() {
     }, 6000);
     return () => clearInterval(interval);
   }, [keynoteSpeakers.length]);
-
-  // EFFECT: Check if the date is past March 13, 2026.
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      const badgeCutoffDate = new Date('2026-03-13T00:00:00-04:00');
-      const ctaCutoffDate = new Date('2026-03-14T00:00:00-04:00');
-      const now = new Date();
-
-      if (now >= badgeCutoffDate) {
-        setShowRegistrationBadge(false);
-      }
-
-      if (now >= ctaCutoffDate) {
-        setShowRegistrationCTA(false);
-      }
-    }, 0);
-    return () => clearTimeout(timer);
-  }, []);
 
   return (
     <div className="flex min-h-screen flex-col pt-16">
@@ -77,15 +55,10 @@ export default function Home() {
           {/* Text Content */}
           <div>
             {/* Status Badge */}
-            {showRegistrationBadge && (
-              <div className="text-ousac-blue mb-6 inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-4 py-1.5 text-xs font-bold tracking-widest uppercase">
-                <span className="relative flex h-2 w-2">
-                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75"></span>
-                  <span className="bg-ousac-blue relative inline-flex h-2 w-2 rounded-full"></span>
-                </span>
-                {SITE_CONTENT.hero.statusBadge}
-              </div>
-            )}
+            <div className="text-ousac-blue mb-6 inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-4 py-1.5 text-xs font-bold tracking-widest uppercase">
+              <span className="bg-ousac-blue relative inline-flex h-2 w-2 rounded-full"></span>
+              {SITE_CONTENT.hero.statusBadge}
+            </div>
 
             {/* Main Headline */}
             <h1 className="font-display text-ousac-black mb-6 text-6xl leading-[0.9] font-bold tracking-tight sm:text-7xl lg:text-8xl">
@@ -101,17 +74,12 @@ export default function Home() {
 
             {/* CTA Buttons */}
             <div className="flex flex-col items-start gap-4 sm:flex-row">
-              {showRegistrationCTA && (
-                <AnimatedShinyButton url="/register">
-                  {SITE_CONTENT.hero.ctaMain}
-                </AnimatedShinyButton>
-              )}
+              <AnimatedShinyButton url={SITE_CONTENT.socials.instagram}>
+                {SITE_CONTENT.hero.ctaMain}
+              </AnimatedShinyButton>
               <Link
                 href="/conference/schedule"
                 className="text-ousac-black hover:border-ousac-blue hover:text-ousac-blue inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white px-8 py-3 text-sm font-bold tracking-wider uppercase transition-colors hover:bg-gray-50"
-                // Adjusted padding/rounded to match the Shiny button roughly if needed,
-                // but kept similar specific styles.
-                // Note: Shiny button has specific padding/rounded.
               >
                 {SITE_CONTENT.hero.ctaSecondary}
               </Link>
@@ -128,7 +96,7 @@ export default function Home() {
                     Date
                   </p>
                   <p className="text-lg font-semibold text-gray-900">
-                    March 14, 2026
+                    {SITE_CONTENT.hero.date}
                   </p>
                 </div>
               </div>
@@ -142,7 +110,7 @@ export default function Home() {
                     Location
                   </p>
                   <p className="text-lg font-semibold text-gray-900">
-                    University of Toronto
+                    {SITE_CONTENT.hero.location}
                   </p>
                 </div>
               </div>

--- a/src/app/payment/success/page.tsx
+++ b/src/app/payment/success/page.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 import Link from 'next/link';
-import { CheckCircle, Calendar, MapPin, Mail } from 'lucide-react';
 import type { Metadata } from 'next';
+import { SITE_CONTENT } from '@/lib/constants';
 
 export const metadata: Metadata = {
-  title: 'Payment Successful | OUSAC 2026',
-  description: 'Your OUSAC 2026 Conference registration is confirmed.',
+  title: 'Conference Update | OUSAC',
+  description:
+    'OUSAC 2026 has wrapped. Follow @ousacsportsanalytics for updates on OUSAC 2027.',
   robots: 'noindex, nofollow',
 };
 
@@ -13,85 +13,31 @@ export default function PaymentSuccess() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white pt-24 pb-24">
       <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <div className="text-center">
-          {/* Success Icon */}
-          <div className="mx-auto mb-8 flex h-24 w-24 items-center justify-center rounded-full bg-green-100">
-            <CheckCircle className="h-16 w-16 text-green-600" />
-          </div>
+        <div className="rounded-[2rem] border border-blue-100 bg-white p-10 text-center shadow-xl shadow-blue-900/5">
+          <span className="text-ousac-blue mb-4 inline-flex items-center rounded-full border border-blue-100 bg-blue-50 px-4 py-1.5 text-xs font-bold tracking-widest uppercase">
+            Conference Update
+          </span>
 
-          {/* Success Message */}
           <h1 className="font-display text-ousac-blue mb-4 text-4xl font-bold sm:text-5xl">
-            Payment Successful!
+            OUSAC 2026 is over!
           </h1>
-          <p className="mb-12 text-xl text-gray-600">
-            Thank you for registering for OUSAC. We're excited to see you there!
+          <p className="mx-auto mb-10 max-w-2xl text-lg leading-relaxed text-gray-600">
+            Follow us on Instagram @ousacsportsanalytics to stay tuned for OUSAC
+            2027.
           </p>
 
-          {/* Confirmation Details Card */}
-          <div className="mb-12 rounded-2xl border border-gray-200 bg-white p-8 text-left shadow-lg">
-            <h2 className="font-display mb-6 text-2xl font-bold text-gray-900">
-              What's Next?
-            </h2>
-
-            <div className="space-y-4">
-              <div className="flex items-start gap-4">
-                <div className="text-ousac-blue rounded-lg bg-blue-100 p-2">
-                  <Mail className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="font-semibold text-gray-900">
-                    Check Your Email
-                  </p>
-                  <p className="text-sm text-gray-600">
-                    You'll receive a confirmation email from Stripe with your
-                    receipt and ticket details.
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-start gap-4">
-                <div className="text-ousac-blue rounded-lg bg-blue-100 p-2">
-                  <Calendar className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="font-semibold text-gray-900">Save the Date</p>
-                  <p className="text-sm text-gray-600">
-                    March 14, 2026 - Mark your calendar for an incredible day of
-                    sports analytics.
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-start gap-4">
-                <div className="text-ousac-blue rounded-lg bg-blue-100 p-2">
-                  <MapPin className="h-5 w-5" />
-                </div>
-                <div>
-                  <p className="font-semibold text-gray-900">
-                    Location Details
-                  </p>
-                  <p className="text-sm text-gray-600">
-                    Bahen Centre, University of Toronto - 40 St. George St,
-                    Toronto, ON
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Action Buttons */}
           <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-            <Link
-              href="/conference/schedule"
+            <a
+              href={SITE_CONTENT.socials.instagram}
               className="bg-ousac-blue hover:bg-ousac-blue/90 inline-flex items-center justify-center rounded-lg px-8 py-3 text-sm font-bold tracking-wider text-white uppercase transition-colors"
             >
-              View Schedule
-            </Link>
+              Follow on Instagram
+            </a>
             <Link
-              href="/conference/speakers"
+              href="/conference/schedule"
               className="text-ousac-blue hover:border-ousac-blue inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white px-8 py-3 text-sm font-bold tracking-wider uppercase transition-colors"
             >
-              Meet the Speakers
+              View Schedule
             </Link>
           </div>
         </div>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,222 +1,54 @@
-import { TICKET_CONTENT, STRIPE_PAYMENT_LINKS } from '@/lib/constants';
+import Link from 'next/link';
 import type { Metadata } from 'next';
+import { AnimatedShinyButton } from '@/components/ui/animated-shiny-button';
+import { SITE_CONTENT } from '@/lib/constants';
 
 export const metadata: Metadata = {
-  title: 'Register | OUSAC 2026',
+  title: 'OUSAC 2026 Is Over | OUSAC',
   description:
-    'Register for the 2nd annual OUSAC Conference on March 14, 2026 at the University of Toronto.',
+    'OUSAC 2026 has wrapped. Follow @ousacsportsanalytics on Instagram for OUSAC 2027 updates.',
 };
 
-export default function Register() {
+export default function RegisterPage() {
   return (
-    <div className="bg-gradient-to-b from-white to-blue-50 pt-10 pb-10 lg:pt-24 lg:pb-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        {/* Page Header */}
-        <div className="mx-auto mb-8 max-w-4xl text-center lg:mb-16">
-          <span className="text-ousac-purple mb-2 block text-xs font-bold tracking-widest uppercase">
-            Registration
+    <div className="bg-gradient-to-b from-white to-blue-50 pt-20 pb-20 lg:pt-28 lg:pb-28">
+      <div className="mx-auto max-w-4xl px-6 lg:px-8">
+        <div className="rounded-[2rem] border border-blue-100 bg-white p-8 text-center shadow-xl shadow-blue-900/5 sm:p-12">
+          <span className="text-ousac-blue mb-4 inline-flex items-center rounded-full border border-blue-100 bg-blue-50 px-4 py-1.5 text-xs font-bold tracking-widest uppercase">
+            Conference Update
           </span>
-          <h1 className="font-display text-ousac-black mb-6 text-4xl font-bold sm:text-5xl">
-            2026 OUSAC Conference Registration
+
+          <h1 className="font-display text-ousac-black mb-6 text-4xl font-bold sm:text-5xl lg:text-6xl">
+            OUSAC 2026 is over!
           </h1>
-          <div className="rounded-xl border border-blue-200 bg-white p-5 text-left shadow-sm lg:p-8">
-            <p className="mb-4 text-lg leading-relaxed text-gray-700">
-              Please fill out this form to register for the 2nd annual OUSAC
-              Conference! The conference will take place on{' '}
-              <strong>Saturday, March 14, 2026 from 9 AM - 5 PM</strong> at the{' '}
-              <strong>University of Toronto</strong>.
-            </p>
-            <p className="mb-4 text-gray-600">
-              There will be a series of invited talks, a panel discussion,
-              student presentations, and data challenge showcases. Registration
-              is limited.
-            </p>
-            <p className="mb-4 text-gray-600">
-              Questions and suggestions can be sent to{' '}
-              <a
-                href="mailto:info.ousac@gmail.com"
-                className="text-ousac-blue font-semibold hover:underline"
-              >
-                info.ousac@gmail.com
-              </a>
-              .
-            </p>
-            <div className="rounded-lg bg-red-50 p-4">
-              <p className="text-sm font-semibold text-red-800">
-                ⏰ The deadline for in-person registration is{' '}
-                <strong>Wednesday, March 11 at 11:59 PM ET</strong>.
-              </p>
-            </div>
-          </div>
-        </div>
 
-        {/* Ticket Selection Section */}
-        <div className="mx-auto max-w-7xl">
-          <h2 className="font-display mb-8 text-center text-3xl font-bold text-gray-900">
-            Select Your Ticket
-          </h2>
+          <p className="mx-auto mb-4 max-w-2xl text-lg leading-relaxed text-gray-700">
+            Thanks to everyone who joined us at the University of Toronto on
+            March 14, 2026. Follow us on Instagram @ousacsportsanalytics to stay
+            tuned for OUSAC 2027.
+          </p>
 
-          {/* Ticket Cards Grid */}
-          <div className="mb-12 grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-8 lg:grid-cols-3">
-            {/* Professional Ticket Card */}
-            <div className="hover:border-ousac-blue overflow-hidden rounded-2xl border-2 border-gray-200 bg-white shadow-lg transition-all duration-300 hover:shadow-xl">
-              <div className="bg-gray-50 p-5 text-center md:p-6">
-                <p className="mb-2 text-sm font-semibold tracking-wider text-gray-500 uppercase">
-                  {TICKET_CONTENT.regularTicket.name}
-                </p>
-                <p className="text-ousac-blue text-5xl font-bold">
-                  {TICKET_CONTENT.regularTicket.price}{' '}
-                  <span className="text-lg text-gray-500">CAD</span>
-                </p>
-              </div>
-              <div className="p-5 md:p-6">
-                <ul className="mb-6 space-y-3">
-                  {TICKET_CONTENT.regularTicket.features.map((feature, idx) => (
-                    <li key={idx} className="flex items-start gap-3">
-                      <div className="mt-0.5 flex-shrink-0">
-                        <div className="flex h-5 w-5 items-center justify-center rounded-full bg-green-100">
-                          <svg
-                            className="h-3 w-3 text-green-600"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M5 13l4 4L19 7"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                      <span className="text-sm text-gray-600">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-                <a
-                  href={STRIPE_PAYMENT_LINKS.regularTicket}
-                  className="bg-ousac-blue hover:bg-ousac-blue/90 block w-full rounded-lg py-4 text-center text-sm font-bold tracking-wider text-white uppercase transition-all hover:shadow-md"
-                >
-                  Register as Professional
-                </a>
-              </div>
-            </div>
+          <p className="mx-auto mb-10 max-w-2xl text-sm leading-relaxed text-gray-500 sm:text-base">
+            Questions can still be sent to{' '}
+            <a
+              href="mailto:info.ousac@gmail.com"
+              className="text-ousac-blue font-semibold hover:underline"
+            >
+              info.ousac@gmail.com
+            </a>
+            .
+          </p>
 
-            {/* Student Ticket Card */}
-            <div className="border-ousac-gold relative overflow-hidden rounded-2xl border-2 bg-white shadow-lg transition-all duration-300 hover:shadow-xl">
-              <div className="bg-ousac-gold absolute top-4 right-4 z-10 rounded-full px-4 py-1.5">
-                <span className="text-xs font-bold text-white uppercase">
-                  {TICKET_CONTENT.studentTicket.badge}
-                </span>
-              </div>
-              <div className="from-ousac-gold/10 to-ousac-gold/5 bg-gradient-to-br p-5 text-center md:p-6">
-                <p className="mb-2 text-sm font-semibold tracking-wider text-gray-500 uppercase">
-                  {TICKET_CONTENT.studentTicket.name}
-                </p>
-                <p className="text-ousac-blue text-5xl font-bold">
-                  {TICKET_CONTENT.studentTicket.price}{' '}
-                  <span className="text-lg text-gray-500">CAD</span>
-                </p>
-              </div>
-              <div className="p-5 md:p-6">
-                <ul className="mb-6 space-y-3">
-                  {TICKET_CONTENT.studentTicket.features.map((feature, idx) => (
-                    <li key={idx} className="flex items-start gap-3">
-                      <div className="mt-0.5 flex-shrink-0">
-                        <div className="flex h-5 w-5 items-center justify-center rounded-full bg-green-100">
-                          <svg
-                            className="h-3 w-3 text-green-600"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M5 13l4 4L19 7"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                      <span className="text-sm text-gray-600">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-                <a
-                  href={STRIPE_PAYMENT_LINKS.studentTicket}
-                  className="bg-ousac-blue hover:bg-ousac-blue/90 block w-full rounded-lg py-4 text-center text-sm font-bold tracking-wider text-white uppercase transition-all hover:shadow-md"
-                >
-                  Register as Student
-                </a>
-              </div>
-            </div>
-
-            {/* Virtual Ticket Card */}
-            <div className="relative overflow-hidden rounded-2xl border-2 border-green-500 bg-white shadow-lg transition-all duration-300 hover:shadow-xl">
-              <div className="absolute top-4 right-4 z-10 rounded-full bg-green-500 px-4 py-1.5">
-                <span className="text-xs font-bold text-white uppercase">
-                  {TICKET_CONTENT.virtualTicket.badge}
-                </span>
-              </div>
-              <div className="bg-gradient-to-br from-green-50 to-blue-50 p-5 text-center md:p-6">
-                <p className="mb-2 text-sm font-semibold tracking-wider text-gray-500 uppercase">
-                  {TICKET_CONTENT.virtualTicket.name}
-                </p>
-                <p className="text-ousac-blue text-5xl font-bold">
-                  {TICKET_CONTENT.virtualTicket.price}
-                </p>
-              </div>
-              <div className="p-5 md:p-6">
-                <ul className="mb-6 space-y-3">
-                  {TICKET_CONTENT.virtualTicket.features.map((feature, idx) => (
-                    <li key={idx} className="flex items-start gap-3">
-                      <div className="mt-0.5 flex-shrink-0">
-                        <div className="flex h-5 w-5 items-center justify-center rounded-full bg-green-100">
-                          <svg
-                            className="h-3 w-3 text-green-600"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M5 13l4 4L19 7"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                      <span className="text-sm text-gray-600">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-                {TICKET_CONTENT.virtualTicket.note && (
-                  <div className="mb-4 rounded-lg bg-yellow-50 p-3">
-                    <p className="text-xs text-yellow-800">
-                      ⚠️ {TICKET_CONTENT.virtualTicket.note}
-                    </p>
-                  </div>
-                )}
-                <a
-                  href={STRIPE_PAYMENT_LINKS.virtualTicket}
-                  className="block w-full rounded-lg bg-green-600 py-4 text-center text-sm font-bold tracking-wider text-white uppercase transition-all hover:bg-green-700 hover:shadow-md"
-                >
-                  Register for Virtual
-                </a>
-              </div>
-            </div>
-          </div>
-
-          {/* Additional Information */}
-          <div className="rounded-xl border border-blue-200 bg-white p-6 text-center">
-            <p className="text-sm text-gray-600">
-              After clicking your ticket type, you&apos;ll be redirected to a
-              secure checkout page where you&apos;ll provide your information
-              and complete registration.
-            </p>
+          <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <AnimatedShinyButton url={SITE_CONTENT.socials.instagram}>
+              Follow on Instagram
+            </AnimatedShinyButton>
+            <Link
+              href="/past-conferences"
+              className="text-ousac-black hover:border-ousac-blue hover:text-ousac-blue inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white px-8 py-3 text-sm font-bold tracking-wider uppercase transition-colors hover:bg-gray-50"
+            >
+              Past Conferences
+            </Link>
           </div>
         </div>
       </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -22,6 +22,7 @@ import {
   Trophy,
   Database,
 } from 'lucide-react';
+import { SITE_CONTENT } from '@/lib/constants';
 
 const Navbar: React.FC = () => {
   const CONFERENCE_ITEMS = [
@@ -58,11 +59,12 @@ const Navbar: React.FC = () => {
               <NavDropdown label="Conference" items={CONFERENCE_ITEMS} />
               <NavItems items={MAIN_NAV_ITEMS} />
               <div className="ml-4">
-                <a href="/register">
-                  <AnimatedShinyButton className="rounded-full !px-6 !py-2">
-                    Register
-                  </AnimatedShinyButton>
-                </a>
+                <AnimatedShinyButton
+                  url={SITE_CONTENT.socials.instagram}
+                  className="rounded-full !px-6 !py-2"
+                >
+                  Instagram
+                </AnimatedShinyButton>
               </div>
             </div>
           </NavBody>
@@ -107,11 +109,12 @@ const Navbar: React.FC = () => {
               </div>
 
               <div className="mt-8">
-                <a href="/register">
-                  <AnimatedShinyButton className="w-full justify-center rounded-full !px-8 !py-3">
-                    Register
-                  </AnimatedShinyButton>
-                </a>
+                <AnimatedShinyButton
+                  url={SITE_CONTENT.socials.instagram}
+                  className="w-full justify-center rounded-full !px-8 !py-3"
+                >
+                  Instagram
+                </AnimatedShinyButton>
               </div>
             </MobileNavMenu>
           </MobileNav>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,76 +16,18 @@ export const SHOW_SPEAKERS = true;
 export const SHOW_SPONSORS = true;
 export const SHOW_SCHEDULE = true;
 
-// Stripe Payment Links (created in Stripe Dashboard)
-export const STRIPE_PAYMENT_LINKS = {
-  regularTicket: 'https://buy.stripe.com/fZueVe4Nffp5cwe8zR9Ve00',
-  studentTicket: 'https://buy.stripe.com/14A7sM5Rj5OvdAi2bt9Ve01',
-  virtualTicket: 'https://buy.stripe.com/28EdRa6Vnel10Nw5nF9Ve02',
-};
-
-export const TICKET_CONTENT = {
-  section: {
-    title: 'Get Your Ticket',
-    subtitle: 'Join us for an unforgettable day of sports analytics',
-    description:
-      'Secure your spot at OUSAC 2026. Choose between in-person attendance or virtual streaming. In-person tickets include catered lunch and networking opportunities.',
-  },
-  regularTicket: {
-    name: 'In-Person - Professional',
-    price: '$10',
-    features: [
-      'In-person attendance at UofT',
-      'Full conference access',
-      'Keynote presentations from industry leaders',
-      'Panel discussions and Q&A sessions',
-      'Student research presentations',
-      'Networking opportunities',
-      'Catered lunch included',
-    ],
-  },
-  studentTicket: {
-    name: 'In-Person - Student',
-    price: '$5',
-    badge: 'Student Discount',
-    features: [
-      'In-person attendance at UofT',
-      'Full conference access',
-      'Keynote presentations from industry leaders',
-      'Panel discussions and Q&A sessions',
-      'Student research presentations',
-      'Networking opportunities',
-      'Catered lunch included',
-    ],
-    honorSystemNote:
-      'This ticket operates on an honor system. No student verification required.',
-  },
-  virtualTicket: {
-    name: 'Virtual Attendance',
-    price: 'Free',
-    badge: 'Remote',
-    features: [
-      'Live stream access to all keynotes',
-      'Live stream of panel discussions',
-      'Access to student presentations',
-      'Q&A participation via chat',
-      'Digital conference materials',
-    ],
-    note: 'Virtual ticket does not grant in-person entry. You must purchase an in-person ticket to attend physically.',
-  },
-};
-
 export const SITE_CONTENT = {
   navbar: {
     title: 'OUSAC',
     logoAlt: 'OUSAC Logo',
   },
   hero: {
-    statusBadge: 'Registration Open',
-    headlinePrefix: 'Data Driven.',
-    headlineSuffix: 'Game Changing.',
+    statusBadge: 'Conference Update',
+    headlinePrefix: 'OUSAC 2026',
+    headlineSuffix: 'is over!',
     subtext:
-      'The 2nd Annual Ontario Universities Sports Analytics Conference. Where academic rigor meets professional application.',
-    ctaMain: 'Register',
+      'Follow us on Instagram @ousacsportsanalytics to stay tuned for OUSAC 2027.',
+    ctaMain: 'Follow on Instagram',
     ctaSecondary: 'View Schedule',
     date: 'March 14, 2026',
     location: 'University of Toronto',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -27,8 +33,10 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- replace registration CTAs with post-event Instagram messaging across the homepage and nav
- convert the register and payment success pages into post-event update pages
- remove unused ticket/Stripe content and add a minimal /call-for-papers stub so Next 16 route validation builds cleanly on latest main

## Testing
- npm run build